### PR TITLE
[WIP] Added conversion scripts for stellar abundance data.

### DIFF
--- a/data/StellarAbundances/conversion/convertBai04.py
+++ b/data/StellarAbundances/conversion/convertBai04.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Bai_2004.txt"
+
+output_directory = "../"
+output_filename = "Bai04_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3, usecols=[1, 2])
+FeH_bai = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_bai = data[:, 1] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_bai * unyt.dimensionless)
+y = unyt.unyt_array(OFe_bai * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Bai et al. (2004)"
+bibcode = "2004A&A...425..671B"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertCayrel04.py
+++ b/data/StellarAbundances/conversion/convertCayrel04.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Cayrel_2004.txt"
+
+output_directory = "../"
+output_filename = "Cayrel04_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=18, usecols=[2, 6])
+FeH_cayrel = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_cayrel = data[:, 1] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_cayrel * unyt.dimensionless)
+y = unyt.unyt_array(OFe_cayrel * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Cayrel et al. (2004)"
+bibcode = "2004A&A...416.1117C"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertGeisler05.py
+++ b/data/StellarAbundances/conversion/convertGeisler05.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Geisler_2005.txt"
+
+output_directory = "../"
+output_filename = "Geisler05_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3)
+FeH_scu = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_scu = data[:, 4] - data[:, 0] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_scu * unyt.dimensionless)
+y = unyt.unyt_array(OFe_scu * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Geisler et al. (2005)"
+bibcode = "2005AJ....129.1428G"
+name = "[O/Fe] as a function of [Fe/H] for Sculptor"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertIsraelian98.py
+++ b/data/StellarAbundances/conversion/convertIsraelian98.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Israelian_1998.txt"
+
+output_directory = "../"
+output_filename = "Israelian98_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3, usecols=[1, 3])
+FeH_isra = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_isra = data[:, 1] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_isra * unyt.dimensionless)
+y = unyt.unyt_array(OFe_isra * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Israelian et al. (1998)"
+bibcode = "1998ApJ...507..805I"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertKoch08.py
+++ b/data/StellarAbundances/conversion/convertKoch08.py
@@ -1,0 +1,64 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Koch_2008.txt"
+
+output_directory = "../"
+output_filename = "Koch08_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3)
+FeH_koch = data[:, 1] + Fe_over_H_AG89 - Fe_over_H
+OH_koch = data[:, 2]
+OFe_koch = OH_koch - FeH_koch + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_koch * unyt.dimensionless)
+y = unyt.unyt_array(OFe_koch * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Kock et al. (2008)"
+bibcode = "unknown"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertLetarte07.py
+++ b/data/StellarAbundances/conversion/convertLetarte07.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Letarte_2007.txt"
+
+output_directory = "../"
+output_filename = "Letarte07_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=1)
+FeH_fornax = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_fornax = data[:, 4] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_fornax * unyt.dimensionless)
+y = unyt.unyt_array(OFe_fornax * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Letarte (2007)"
+bibcode = "2007PhDT.......302L"
+name = "[O/Fe] as a function of [Fe/H] for Fornax"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertMishenina00.py
+++ b/data/StellarAbundances/conversion/convertMishenina00.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Mishenina_1999.txt"
+
+output_directory = "../"
+output_filename = "Mishenina00_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3, usecols=[1, 3])
+FeH_mish = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_mish = data[:, 1] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_mish * unyt.dimensionless)
+y = unyt.unyt_array(OFe_mish * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Mishenina et al. (2000)"
+bibcode = "2000A&A...353..978M"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertSbordone07.py
+++ b/data/StellarAbundances/conversion/convertSbordone07.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Sbordone_2007.txt"
+
+output_directory = "../"
+output_filename = "Sbordone07_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=1)
+FeH_sg = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_sg = data[:, 4] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_sg * unyt.dimensionless)
+y = unyt.unyt_array(OFe_sg * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Sbordone et al. (2007)"
+bibcode = "2007A&A...465..815S"
+name = "[O/Fe] as a function of [Fe/H] for Sagittarius"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertTolstoy09.py
+++ b/data/StellarAbundances/conversion/convertTolstoy09.py
@@ -1,0 +1,64 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+output_directory = "../"
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+Mg_over_H = 12.0 - 4.4
+Mg_over_Fe = Mg_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+Mg_over_H_AG89 = 7.58
+
+Mg_over_Fe_AG89 = Mg_over_H_AG89 - Fe_over_H_AG89
+
+for galaxy in ["Carina", "MW", "Fornax", "Sculptor", "Sagittarius"]:
+    input_filename = "../raw/{0}.txt".format(galaxy)
+
+    output_filename = "Tolstoy09_{0}.hdf5".format(galaxy)
+
+    data = np.loadtxt(input_filename)
+    FeH = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+    MgFe = data[:, 1] + Mg_over_Fe_AG89 - Mg_over_Fe
+    x = unyt.unyt_array(FeH * unyt.dimensionless)
+    y = unyt.unyt_array(MgFe * unyt.dimensionless)
+
+    # Meta-data
+    comment = (
+        "Solar abundances are taken from Asplund et al. (2009), "
+        "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+    )
+    citation = "Tolstoy et al. (2009)"
+    bibcode = "2009ARA&A..47..371T"
+    name = "[Mg/Fe] as a function of [Fe/H] for {0}".format(galaxy)
+    plot_as = "points"
+    redshift = 0.0
+
+    # Write everything
+    processed = ObservationalData()
+    processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+    processed.associate_y(y, scatter=None, comoving=False, description="[Mg/Fe]")
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_redshift(redshift)
+    processed.associate_plot_as(plot_as)
+    processed.associate_cosmology(cosmology)
+
+    output_path = f"{output_directory}/{output_filename}"
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    processed.write(filename=output_path)

--- a/data/StellarAbundances/conversion/convertZhangZhao05.py
+++ b/data/StellarAbundances/conversion/convertZhangZhao05.py
@@ -1,0 +1,63 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Zhang_Zhao_2005.txt"
+
+output_directory = "../"
+output_filename = "ZhangZao05_data.hdf5"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+Fe_over_H = 12.0 - 4.5
+O_over_H = 12.0 - 3.31
+O_over_Fe = O_over_H - Fe_over_H
+
+# tabulate/compute the same ratios from Anders & Grevesse (1989)
+Fe_over_H_AG89 = 7.67
+O_over_H_AG89 = 8.93
+
+O_over_Fe_AG89 = O_over_H_AG89 - Fe_over_H_AG89
+
+data = np.loadtxt(input_filename, skiprows=3)
+FeH_zhang = data[:, 0] + Fe_over_H_AG89 - Fe_over_H
+OFe_zhang = data[:, 1] + O_over_Fe_AG89 - O_over_Fe
+x = unyt.unyt_array(FeH_zhang * unyt.dimensionless)
+y = unyt.unyt_array(OFe_zhang * unyt.dimensionless)
+
+# Meta-data
+comment = (
+    "Solar abundances are taken from Asplund et al. (2009), "
+    "[Fe/H]Sun = 7.5 and [Mg/H]Sun = 7.6"
+)
+citation = "Zhang & Zhao (2005)"
+bibcode = "2005MNRAS.364..712Z"
+name = "[O/Fe] as a function of [Fe/H]"
+plot_as = "points"
+redshift = 0.0
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(x, scatter=None, comoving=False, description="[Fe/H]")
+processed.associate_y(y, scatter=None, comoving=False, description="[O/Fe]")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)


### PR DESCRIPTION
First version of conversion scripts that extract the raw stellar abundance data and store them in a format that is compatible with the rest of the pipeline.

The Koch (2008) conversion still lacks a Bibcode and it is currently also not clear where the Kock (2005) data referenced in the figure caption comes from (right now, this is also taken from Koch, 2008 it seems). Once this is clear, this can be merged and then the pull request in the main repository can be merged as well.